### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Subject of the issue
+Describe your issue here.
+
+### Your environment
+* version of `phpunitgen/core`:
+* version of `phpunitgen/console`:
+
+### Steps to reproduce
+Tell us how to reproduce this issue. Please provide a working demo.
+
+### Expected behaviour
+Tell us what should happen.
+
+### Actual behaviour
+Tell us what happens instead.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Your checklist for this pull request
+🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
+
+- [ ] Make sure you are requesting to **pull a feature/fix branch** (right side). Don't request your master!
+- [ ] Check the commit's or even all commits' message styles matches our requested structure.
+- [ ] Check your code additions will fail neither code linting checks nor unit test.
+
+### Description
+Please describe your pull request.
+
+Thank you!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
   pull_request:
-    branches: [master, develop]
+    branches: [main, develop]
   schedule:
     - cron: '0 0 1 * *'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Change Log
 
-## 2.0.0
+## 3.0.0
 
 **Added**
 
-- Add support for PHP `~8.0.12` and `~8.1.0`.
-- Drop support for PHP `7`.
-- Compatibility with Laravel Lumen framework.
+- Support Windows absolute path in other disk than current one.
+- Compatibility with Laravel `9`.
+- Compatibility with Symfony `6` components.
 
 **Changed**
 
-- Runner will now trigger warning instead of error when able to generate tests for a class.
+- Migrate `league/flysystem` from `^1.0`. to `^3.0`.
+
+## 2.0.0
+
+See the [2.x.x CHANGELOG](https://github.com/paul-thebaud/phpunitgen-console/blob/2.x.x/CHANGELOG.md).
 
 ## 1.x.x
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ so don't worry if your code styling isn't perfect!
 - **Document any change in behaviour.** Make sure the `README.md` and any
 other relevant documentation are kept up-to-date.
 
-- **Create feature branches.** Don't ask us to pull from your master branch.
+- **Create feature branches.** Don't ask us to pull from your main branch.
 
 - **One pull request per feature.** If you want to do more than one thing,
 send multiple pull requests.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<p align="center"><img src="https://raw.githubusercontent.com/paul-thebaud/phpunitgen-webapp/master/resources/svg/logo.svg?sanitize=true" alt="PhpUnitGen" height="50"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/paul-thebaud/phpunitgen-webapp/main/resources/svg/logo.svg?sanitize=true" alt="PhpUnitGen" height="50"></p>
 
 <p align="center">
 <a href="https://packagist.org/packages/phpunitgen/console"><img src="https://poser.pugx.org/phpunitgen/console/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/phpunitgen/console"><img src="https://poser.pugx.org/phpunitgen/console/v/stable.svg" alt="Latest Stable Version"></a>
 <a href="https://github.com/paul-thebaud/phpunitgen-console/actions/workflows/main.yml" target="_blank"><img src="https://github.com/paul-thebaud/phpunitgen-console/actions/workflows/main.yml/badge.svg" alt="Build Status"></a>
-<a href="https://github.styleci.io/repos/190246776" target="_blank"><img src="https://github.styleci.io/repos/190246776/shield?branch=master&style=flat" alt="StyleCI"></a>
+<a href="https://github.styleci.io/repos/190246776" target="_blank"><img src="https://github.styleci.io/repos/190246776/shield?branch=main&style=flat" alt="StyleCI"></a>
 <a href="https://sonarcloud.io/dashboard?id=paul-thebaud_phpunitgen-console" target="_blank"><img src="https://sonarcloud.io/api/project_badges/measure?project=paul-thebaud_phpunitgen-console&metric=alert_status" alt="Quality Gate Status"></a>
 <a href="https://sonarcloud.io/dashboard?id=paul-thebaud_phpunitgen-console" target="_blank"><img src="https://sonarcloud.io/api/project_badges/measure?project=paul-thebaud_phpunitgen-console&metric=coverage" alt="Coverage"></a>
 </p>

--- a/composer.json
+++ b/composer.json
@@ -29,18 +29,18 @@
     "php": "~8.0.12 || ~8.1.0",
     "ext-json": "*",
     "league/container": "^3.3",
-    "league/flysystem": "^1.0",
+    "league/flysystem": "^3.0",
     "phpunitgen/core": "^2.0",
-    "symfony/console": "^4.4 || ^5.0",
-    "symfony/stopwatch": "^4.3 || ^5.0",
-    "symfony/yaml": "^4.3 || ^5.0",
+    "symfony/console": "^4.4 || ^5.0 || ^6.0",
+    "symfony/stopwatch": "^4.3 || ^5.0 || ^6.0",
+    "symfony/yaml": "^4.3 || ^5.0 || ^6.0",
     "tightenco/collect": "^8.0"
   },
   "require-dev": {
-    "laravel/framework": "^7.0 || ^8.0",
+    "laravel/framework": "^9.0",
     "mockery/mockery": "^1.3",
-    "orchestra/testbench": "^5.0 || ^6.0",
-    "phpunit/phpunit": "^8.5 || ^9.1"
+    "orchestra/testbench": "^7.0",
+    "phpunit/phpunit": "^9.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/Files/CleansWindowsPaths.php
+++ b/src/Files/CleansWindowsPaths.php
@@ -22,6 +22,6 @@ trait CleansWindowsPaths
      */
     protected function convertPotentialWindowsPath(string $path): string
     {
-        return str_replace('\\', '/', preg_replace('/^[A-Z]:/', '', $path, 1));
+        return str_replace('\\', '/', $path);
     }
 }

--- a/src/Files/LeagueFilesystem.php
+++ b/src/Files/LeagueFilesystem.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace PhpUnitGen\Console\Files;
 
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\FileNotFoundException;
+use League\Flysystem\FileAttributes;
 use League\Flysystem\Filesystem;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\StorageAttributes;
+use League\Flysystem\UnableToReadFile;
 use PhpUnitGen\Console\Contracts\Files\Filesystem as FilesystemContract;
 use PhpUnitGen\Core\Exceptions\InvalidArgumentException;
 use PhpUnitGen\Core\Helpers\Str;
@@ -25,7 +27,7 @@ class LeagueFilesystem implements FilesystemContract
     use CleansWindowsPaths;
 
     /**
-     * @var FilesystemInterface
+     * @var FilesystemOperator
      */
     protected $filesystem;
 
@@ -37,10 +39,10 @@ class LeagueFilesystem implements FilesystemContract
     /**
      * LeagueFilesystem constructor.
      *
-     * @param FilesystemInterface $filesystem
-     * @param string              $currentWorkingDirectory
+     * @param FilesystemOperator $filesystem
+     * @param string             $currentWorkingDirectory
      */
-    public function __construct(FilesystemInterface $filesystem, string $currentWorkingDirectory)
+    public function __construct(FilesystemOperator $filesystem, string $currentWorkingDirectory)
     {
         $this->filesystem = $filesystem;
         $this->currentWorkingDirectory = $this->getCleanedPath($currentWorkingDirectory);
@@ -53,7 +55,12 @@ class LeagueFilesystem implements FilesystemContract
      */
     public static function make(): self
     {
-        $localAdapter = new Local('/', LOCK_EX, Local::SKIP_LINKS);
+        $localAdapter = new LocalFilesystemAdapter(
+            '/',
+            null,
+            LOCK_EX,
+            LocalFilesystemAdapter::SKIP_LINKS
+        );
 
         return new static(new Filesystem($localAdapter), getcwd());
     }
@@ -71,9 +78,7 @@ class LeagueFilesystem implements FilesystemContract
      */
     public function isFile(string $path): bool
     {
-        $type = $this->getPathType($this->getAbsolutePath($path));
-
-        return $type === 'file';
+        return $this->filesystem->fileExists($this->getAbsolutePath($path));
     }
 
     /**
@@ -81,9 +86,7 @@ class LeagueFilesystem implements FilesystemContract
      */
     public function isDirectory(string $path): bool
     {
-        $type = $this->getPathType($this->getAbsolutePath($path));
-
-        return $type === 'dir';
+        return $this->filesystem->directoryExists($this->getAbsolutePath($path));
     }
 
     /**
@@ -96,12 +99,8 @@ class LeagueFilesystem implements FilesystemContract
         );
 
         return $files
-            ->reject(function (array $file) {
-                return $file['type'] !== 'file';
-            })
-            ->map(function (array $file) {
-                return '/'.$file['path'];
-            })
+            ->filter(fn(StorageAttributes $attrs) => $attrs instanceof FileAttributes)
+            ->map(fn(StorageAttributes $attrs) => '/'.$attrs->path())
             ->values();
     }
 
@@ -112,8 +111,8 @@ class LeagueFilesystem implements FilesystemContract
     {
         try {
             return $this->filesystem->read($this->getAbsolutePath($file));
-        } catch (FileNotFoundException $exception) {
-            throw new InvalidArgumentException('file not found: '.$file);
+        } catch (UnableToReadFile $exception) {
+            throw new InvalidArgumentException('file not found: '.$file, 0, $exception);
         }
     }
 
@@ -130,11 +129,7 @@ class LeagueFilesystem implements FilesystemContract
             );
         }
 
-        if ($this->has($path)) {
-            $this->filesystem->update($path, $content);
-        } else {
-            $this->filesystem->write($path, $content);
-        }
+        $this->filesystem->write($path, $content);
     }
 
     /**
@@ -153,7 +148,7 @@ class LeagueFilesystem implements FilesystemContract
             throw new InvalidArgumentException("cannot rename to existing {$newPath}");
         }
 
-        $this->filesystem->rename($absolutePath, $newAbsolutePath);
+        $this->filesystem->move($absolutePath, $newAbsolutePath);
     }
 
     /**
@@ -162,16 +157,6 @@ class LeagueFilesystem implements FilesystemContract
     public function getRoot(): string
     {
         return $this->currentWorkingDirectory.'/';
-    }
-
-    /**
-     * Retrieve the base League filesystem instance.
-     *
-     * @return FilesystemInterface
-     */
-    public function getFilesystem(): FilesystemInterface
-    {
-        return $this->filesystem;
     }
 
     /**
@@ -202,28 +187,5 @@ class LeagueFilesystem implements FilesystemContract
     protected function getCleanedPath(string $path): string
     {
         return $this->convertPotentialWindowsPath($path);
-    }
-
-    /**
-     * Get the type metadata of the given path if possible. Returns null if
-     * not found.
-     *
-     * @param string $path
-     *
-     * @return string|null
-     */
-    protected function getPathType(string $path): ?string
-    {
-        try {
-            $metadata = $this->filesystem->getMetadata($path);
-        } catch (FileNotFoundException $exception) {
-            return null;
-        }
-
-        if (! is_array($metadata) || ! isset($metadata['type'])) {
-            return null;
-        }
-
-        return $metadata['type'];
     }
 }

--- a/src/Files/LeagueFilesystem.php
+++ b/src/Files/LeagueFilesystem.php
@@ -170,7 +170,7 @@ class LeagueFilesystem implements FilesystemContract
     {
         $path = $this->getCleanedPath($path);
 
-        if (Str::startsWith('/', $path)) {
+        if (Str::startsWith('/', $path) || Str::containsRegex('^[A-Z]:', $path)) {
             return $path;
         }
 

--- a/src/Files/LeagueFilesystem.php
+++ b/src/Files/LeagueFilesystem.php
@@ -99,8 +99,8 @@ class LeagueFilesystem implements FilesystemContract
         );
 
         return $files
-            ->filter(fn(StorageAttributes $attrs) => $attrs instanceof FileAttributes)
-            ->map(fn(StorageAttributes $attrs) => '/'.$attrs->path())
+            ->filter(fn (StorageAttributes $attrs) => $attrs instanceof FileAttributes)
+            ->map(fn (StorageAttributes $attrs) => '/'.$attrs->path())
             ->values();
     }
 

--- a/tests/Feature/LaravelIntegrationTest.php
+++ b/tests/Feature/LaravelIntegrationTest.php
@@ -103,9 +103,7 @@ class LaravelIntegrationTest extends TestCase
     {
         $this->artisan('make:controller', ['name' => 'Dummy', '--resource' => true])
             ->expectsOutput('Controller created successfully.')
-            // We won't validate PhpUnitGen written an output, because the
-            // Laravel event output is not a testing one when using 5.8.
-            //->expectsOutput('Test generated for "Http/Controllers/Dummy".')
+            ->expectsOutput('Test generated for "Http/Controllers/Dummy".')
             ->assertExitCode(0);
 
         $this->assertTrue(File::exists(__DIR__.'/orchestra/testbench-core/laravel/app/Http/Controllers/DummyTest.php'));

--- a/tests/Unit/Files/LeagueFilesystemTest.php
+++ b/tests/Unit/Files/LeagueFilesystemTest.php
@@ -61,7 +61,7 @@ class LeagueFilesystemTest extends TestCase
     {
         $this->assertSame(
             $this->convertPotentialWindowsPath('C:\\Test\\Path\\To\\File'),
-            '/Test/Path/To/File'
+            'C:/Test/Path/To/File'
         );
 
         $this->assertSame(
@@ -210,11 +210,13 @@ class LeagueFilesystemTest extends TestCase
 
     public function testItIsCompatibleWithWindowsPaths(): void
     {
-        $windowsLeagueFilesystemC = new LeagueFilesystem($this->filesystem,
-            'C:\Users\John Doe\Documents');
+        $windowsLeagueFilesystemC = new LeagueFilesystem(
+            $this->filesystem,
+            'C:\Users\John Doe\Documents'
+        );
 
         $this->filesystem->shouldReceive('has')->once()
-            ->with('/Users/John Doe/Documents/app/file')
+            ->with('C:/Users/John Doe/Documents/app/file')
             ->andReturnTrue();
 
         $this->assertTrue($windowsLeagueFilesystemC->has('app\file'));
@@ -225,7 +227,7 @@ class LeagueFilesystemTest extends TestCase
         );
 
         $this->filesystem->shouldReceive('has')->once()
-            ->with('/app/file')
+            ->with('C:/app/file')
             ->andReturnTrue();
 
         $this->assertTrue($windowsLeagueFilesystemD->has('C:\app\file'));

--- a/tests/Unit/Files/LeagueFilesystemTest.php
+++ b/tests/Unit/Files/LeagueFilesystemTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\PhpUnitGen\Console\Unit\Files;
 
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\FileNotFoundException;
-use League\Flysystem\Filesystem;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\DirectoryAttributes;
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToReadFile;
 use Mockery;
 use Mockery\Mock;
 use PhpUnitGen\Console\Files\CleansWindowsPaths;
@@ -26,7 +27,7 @@ class LeagueFilesystemTest extends TestCase
     use CleansWindowsPaths;
 
     /**
-     * @var FilesystemInterface|Mock
+     * @var FilesystemOperator|Mock
      */
     protected $filesystem;
 
@@ -42,7 +43,7 @@ class LeagueFilesystemTest extends TestCase
     {
         parent::setUp();
 
-        $this->filesystem = Mockery::mock(FilesystemInterface::class);
+        $this->filesystem = Mockery::mock(FilesystemOperator::class);
         $this->leagueFilesystem = new LeagueFilesystem($this->filesystem, '/john');
     }
 
@@ -50,18 +51,10 @@ class LeagueFilesystemTest extends TestCase
     {
         $leagueFilesystem = LeagueFilesystem::make();
 
-        $this->assertSame($this->convertPotentialWindowsPath(getcwd()).'/', $leagueFilesystem->getRoot());
-
-        /** @var Filesystem $filesystem */
-        $filesystem = $leagueFilesystem->getFilesystem();
-
-        $this->assertInstanceOf(Filesystem::class, $filesystem);
-
-        /** @var Local $adapter */
-        $adapter = $filesystem->getAdapter();
-
-        $this->assertInstanceOf(Local::class, $adapter);
-        $this->assertSame(DIRECTORY_SEPARATOR, $adapter->getPathPrefix());
+        $this->assertSame(
+            $this->convertPotentialWindowsPath(getcwd()).'/',
+            $leagueFilesystem->getRoot()
+        );
     }
 
     public function testItCleansWindowsPaths(): void
@@ -86,65 +79,33 @@ class LeagueFilesystemTest extends TestCase
         $this->assertTrue($this->leagueFilesystem->has('app/file'));
     }
 
-    public function testItChecksIsFile(): void
+    public function testItForwardsFileExists(): void
     {
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/file1')
-            ->andReturn(['type' => 'file']);
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/file2')
-            ->andReturn(['type' => 'dir']);
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/file3')
-            ->andReturnFalse();
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/file4')
-            ->andReturn([]);
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/file5')
-            ->andThrow(new FileNotFoundException('/john/app/file5'));
+        $this->filesystem->shouldReceive('fileExists')->once()
+            ->with('/john/app/file')
+            ->andReturnTrue();
 
-        $this->assertTrue($this->leagueFilesystem->isFile('app/file1'));
-        $this->assertFalse($this->leagueFilesystem->isFile('app/file2'));
-        $this->assertFalse($this->leagueFilesystem->isFile('app/file3'));
-        $this->assertFalse($this->leagueFilesystem->isFile('app/file4'));
-        $this->assertFalse($this->leagueFilesystem->isFile('app/file5'));
+        $this->assertTrue($this->leagueFilesystem->isFile('app/file'));
     }
 
-    public function testItChecksIsDirectory(): void
+    public function testItForwardsDirectoryExists(): void
     {
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/dir1')
-            ->andReturn(['type' => 'dir']);
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/dir2')
-            ->andReturn(['type' => 'file']);
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/dir3')
-            ->andReturnFalse();
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/dir4')
-            ->andReturn([]);
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/dir5')
-            ->andThrow(new FileNotFoundException('/john/app/dir5'));
+        $this->filesystem->shouldReceive('directoryExists')->once()
+            ->with('/john/app/file')
+            ->andReturnTrue();
 
-        $this->assertTrue($this->leagueFilesystem->isDirectory('app/dir1'));
-        $this->assertFalse($this->leagueFilesystem->isDirectory('app/dir2'));
-        $this->assertFalse($this->leagueFilesystem->isDirectory('app/dir3'));
-        $this->assertFalse($this->leagueFilesystem->isDirectory('app/dir4'));
-        $this->assertFalse($this->leagueFilesystem->isDirectory('app/dir5'));
+        $this->assertTrue($this->leagueFilesystem->isDirectory('app/file'));
     }
 
     public function testItListsFiles(): void
     {
         $this->filesystem->shouldReceive('listContents')->once()
             ->with('/john/app/dir', true)
-            ->andReturn([
-                ['type' => 'dir', 'path' => 'john/app/services'],
-                ['type' => 'file', 'path' => 'john/app/file1'],
-                ['type' => 'file', 'path' => 'john/app/services/file2'],
-            ]);
+            ->andReturn(new DirectoryListing([
+                new DirectoryAttributes('john/app/services'),
+                new FileAttributes('john/app/file1'),
+                new FileAttributes('john/app/services/file2'),
+            ]));
 
         $this->assertSame([
             '/john/app/file1',
@@ -162,7 +123,7 @@ class LeagueFilesystemTest extends TestCase
 
         $this->filesystem->shouldReceive('read')->once()
             ->with('/john/app/file_not_found')
-            ->andThrow(new FileNotFoundException('/john/app/file_not_found'));
+            ->andThrow(new UnableToReadFile('/john/app/file_not_found'));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('file not found: app/file_not_found');
@@ -170,26 +131,9 @@ class LeagueFilesystemTest extends TestCase
         $this->assertSame('content', $this->leagueFilesystem->read('app/file_not_found'));
     }
 
-    public function testItForwardsWriteWithExistingFile(): void
+    public function testItForwardsWriteWithoutExistingDirectory(): void
     {
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/file')
-            ->andReturn(['type' => 'file']);
-        $this->filesystem->shouldReceive('has')->once()
-            ->with('/john/app/file')
-            ->andReturnTrue();
-        $this->filesystem->shouldReceive('update')->once()
-            ->with('/john/app/file', 'content');
-
-        $this->leagueFilesystem->write('app/file', 'content');
-    }
-
-    public function testItForwardsWriteWithNonExistingFile(): void
-    {
-        $this->filesystem->shouldReceive('getMetadata')->once()
-            ->with('/john/app/file')
-            ->andThrow(new FileNotFoundException('/john/app/file'));
-        $this->filesystem->shouldReceive('has')->once()
+        $this->filesystem->shouldReceive('directoryExists')->once()
             ->with('/john/app/file')
             ->andReturnFalse();
         $this->filesystem->shouldReceive('write')->once()
@@ -200,9 +144,9 @@ class LeagueFilesystemTest extends TestCase
 
     public function testItForwardsWriteWithExistingDirectory(): void
     {
-        $this->filesystem->shouldReceive('getMetadata')->once()
+        $this->filesystem->shouldReceive('directoryExists')->once()
             ->with('/john/app/file')
-            ->andReturn(['type' => 'dir']);
+            ->andReturnTrue();
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('cannot write file because directory with same name exists: app/file');
@@ -218,7 +162,7 @@ class LeagueFilesystemTest extends TestCase
         $this->filesystem->shouldReceive('has')->once()
             ->with('/john/app/target')
             ->andReturnFalse();
-        $this->filesystem->shouldReceive('rename')->once()
+        $this->filesystem->shouldReceive('move')->once()
             ->with('/john/app/source', '/john/app/target');
 
         $this->leagueFilesystem->rename('app/source', 'app/target');
@@ -266,7 +210,8 @@ class LeagueFilesystemTest extends TestCase
 
     public function testItIsCompatibleWithWindowsPaths(): void
     {
-        $windowsLeagueFilesystemC = new LeagueFilesystem($this->filesystem, 'C:\Users\John Doe\Documents');
+        $windowsLeagueFilesystemC = new LeagueFilesystem($this->filesystem,
+            'C:\Users\John Doe\Documents');
 
         $this->filesystem->shouldReceive('has')->once()
             ->with('/Users/John Doe/Documents/app/file')
@@ -274,7 +219,10 @@ class LeagueFilesystemTest extends TestCase
 
         $this->assertTrue($windowsLeagueFilesystemC->has('app\file'));
 
-        $windowsLeagueFilesystemD = new LeagueFilesystem($this->filesystem, 'D:\Users\John Doe\Documents');
+        $windowsLeagueFilesystemD = new LeagueFilesystem(
+            $this->filesystem,
+            'D:\Users\John Doe\Documents'
+        );
 
         $this->filesystem->shouldReceive('has')->once()
             ->with('/app/file')

--- a/tests/Unit/Files/SourcesResolverTest.php
+++ b/tests/Unit/Files/SourcesResolverTest.php
@@ -63,7 +63,7 @@ class SourcesResolverTest extends TestCase
             ->andReturnTrue();
 
         $this->assertSame([
-            '/path/to/project/source.php',
+            'C:/path/to/project/source.php',
         ], $this->sourcesResolver->resolve($config, 'C:\path\to\project\source.php')->toArray());
     }
 


### PR DESCRIPTION
Resolves https://github.com/paul-thebaud/phpunitgen-core/issues/17

**Added**

- Support Windows absolute path in other disk than current one.
- Compatibility with Laravel `9`.
- Compatibility with Symfony `6` components.

**Changed**

- Migrate `league/flysystem` from `^1.0`. to `^3.0`.